### PR TITLE
Switch from getURLSpecFromFile to getURLSpecFromActualFile

### DIFF
--- a/experiments.js
+++ b/experiments.js
@@ -67,7 +67,7 @@ function paint(win) {
     }
     var url = Services.io.getProtocolHandler("file").
         QueryInterface(Components.interfaces.nsIFileProtocolHandler).
-        getURLSpecFromFile(file);
+        getURLSpecFromActualFile(file);
     Services.scriptloader.loadSubScriptWithOptions(url, {
         target: win.document.defaultView,
         charset: "UTF-8",


### PR DESCRIPTION
For Thunderbird 92 compatibility

https://bugzilla.mozilla.org/show_bug.cgi?id=1723811
https://bugzilla.mozilla.org/show_bug.cgi?id=1723807

Not tested on TB 91, but it looks like [getURLSpecFromActualFile existed there](https://searchfox.org/mozilla-esr91/search?q=getURLSpecFromActualFile&path=&case=false&regexp=false).